### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 # Paperless-NGX MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@nloui/paperless-mcp)](https://smithery.ai/server/@nloui/paperless-mcp)
+
 An MCP (Model Context Protocol) server for interacting with a Paperless-NGX API server. This server provides tools for managing documents, tags, correspondents, and document types in your Paperless-NGX instance.
 
 ## Quick Start
 
+### Installing via Smithery
+
+To install Paperless NGX MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@nloui/paperless-mcp):
+
+```bash
+npx -y @smithery/cli install @nloui/paperless-mcp --client claude
+```
+
+### Manual Installation
 1. Install the MCP server:
 ```bash
 npm install -g paperless-mcp


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Paperless NGX for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@nloui/paperless-mcp

Let me know if any tweaks have to be made!