### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 An MCP (Model Context Protocol) server for interacting with a Paperless-NGX API server. This server provides tools for managing documents, tags, correspondents, and document types in your Paperless-NGX instance.
 
+<a href="https://glama.ai/mcp/servers/ng04du3voj">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/ng04du3voj/badge" alt="Paperless-NGX Server MCP server" />
+</a>
+
 ## Quick Start
 
 ### Installing via Smithery
@@ -154,7 +158,7 @@ Parameters:
   - permissions: Object for set_permissions with owner, permissions, merge flag
   - metadata_document_id: ID for merge to specify metadata source
   - delete_originals: Boolean for merge/split
-  - pages: String for split "[1,2-3,4,5-7]" or delete_pages "[2,3,4]"
+  - pages: String for split "[1,2-3,4,5]" or delete_pages "[2,3,4]"
   - degrees: Number for rotate (90, 180, or 270)
 
 Examples:


### PR DESCRIPTION
This PR adds a badge for the [Paperless-NGX MCP Server](https://glama.ai/mcp/servers/ng04du3voj) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/ng04du3voj">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/ng04du3voj/badge" alt="Paperless-NGX Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.