### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/src/tools/correspondents.ts
+++ b/src/tools/correspondents.ts
@@ -5,7 +5,12 @@ export function registerCorrespondentTools(server: McpServer, api) {
   server.tool(
     "list_correspondents",
     "Retrieve all available correspondents (people, companies, organizations that send/receive documents). Returns names and automatic matching patterns for document assignment.",
-    { }, async (args, extra) => {
+    { },
+    {
+      title: "List Correspondents",
+      readOnlyHint: true,
+    },
+    async (args, extra) => {
     if (!api) throw new Error("Please configure API connection first");
     return api.getCorrespondents();
   });
@@ -19,6 +24,10 @@ export function registerCorrespondentTools(server: McpServer, api) {
       matching_algorithm: z
         .enum(["any", "all", "exact", "regular expression", "fuzzy"])
         .optional().describe("How to match text patterns: 'any'=any word matches, 'all'=all words must match, 'exact'=exact phrase match, 'regular expression'=use regex patterns, 'fuzzy'=approximate matching with typos. Default is 'any'."),
+    },
+    {
+      title: "Create Correspondent",
+      destructiveHint: true,
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
@@ -46,6 +55,10 @@ export function registerCorrespondentTools(server: McpServer, api) {
         })
         .optional().describe("Permission settings when operation is 'set_permissions'. Defines who can view/assign and modify these correspondents."),
       merge: z.boolean().optional().describe("Whether to merge with existing permissions (true) or replace them entirely (false). Default is false."),
+    },
+    {
+      title: "Bulk Edit Correspondents",
+      destructiveHint: true,
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");

--- a/src/tools/documentTypes.ts
+++ b/src/tools/documentTypes.ts
@@ -6,7 +6,12 @@ export function registerDocumentTypeTools(server, api) {
     "Retrieve all available document types for categorizing documents by purpose or format (Invoice, Receipt, Contract, etc.). Returns names and automatic matching rules.",
     {
     // No parameters - returns all available document types
-  }, async (args, extra) => {
+  },
+  {
+    title: "List Document Types",
+    readOnlyHint: true,
+  },
+  async (args, extra) => {
     if (!api) throw new Error("Please configure API connection first");
     return api.getDocumentTypes();
   });
@@ -20,6 +25,10 @@ export function registerDocumentTypeTools(server, api) {
       matching_algorithm: z
         .enum(["any", "all", "exact", "regular expression", "fuzzy"])
         .optional().describe("How to match text patterns: 'any'=any word matches, 'all'=all words must match, 'exact'=exact phrase match, 'regular expression'=use regex patterns, 'fuzzy'=approximate matching with typos. Default is 'any'."),
+    },
+    {
+      title: "Create Document Type",
+      destructiveHint: true,
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
@@ -47,6 +56,10 @@ export function registerDocumentTypeTools(server, api) {
         })
         .optional().describe("Permission settings when operation is 'set_permissions'. Defines who can view/assign and modify these document types."),
       merge: z.boolean().optional().describe("Whether to merge with existing permissions (true) or replace them entirely (false). Default is false."),
+    },
+    {
+      title: "Bulk Edit Document Types",
+      destructiveHint: true,
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -50,6 +50,10 @@ export function registerDocumentTools(server, api) {
       pages: z.string().optional().describe("Page specification for delete_pages method. Format: '1,3,5-7' to delete pages 1, 3, and 5 through 7."),
       degrees: z.number().optional().describe("Rotation angle in degrees when method is 'rotate'. Use 90, 180, or 270 for standard rotations."),
     },
+    {
+      title: "Bulk Edit Documents",
+      destructiveHint: true,
+    },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const { documents, method, ...parameters } = args;
@@ -72,6 +76,10 @@ export function registerDocumentTools(server, api) {
       archive_serial_number: z.string().optional().describe("Custom archive number for document organization and reference. Useful for maintaining external filing systems."),
       custom_fields: z.array(z.number()).optional().describe("Array of custom field IDs to associate with this document. Custom fields store additional metadata."),
     },
+    {
+      title: "Post Document",
+      destructiveHint: true,
+    },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const binaryData = Buffer.from(args.file, "base64");
@@ -89,6 +97,10 @@ export function registerDocumentTools(server, api) {
     {
       id: z.number().describe("Unique document ID. Get this from search_documents results. Returns full document metadata, content preview, and associated tags/correspondent/type."),
     },
+    {
+      title: "Get Document",
+      readOnlyHint: true,
+    },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       return api.getDocument(args.id);
@@ -103,6 +115,10 @@ export function registerDocumentTools(server, api) {
       page: z.number().optional().describe("Page number for pagination (starts at 1). Use to browse through large result sets without hitting token limits."),
       page_size: z.number().optional().describe("Number of documents per page (default 25, max 100). Smaller page sizes help avoid token limits when many documents match."),
     },
+    {
+      title: "Search Documents",
+      readOnlyHint: true,
+    },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       return api.searchDocuments(args.query, args.page, args.page_size);
@@ -115,6 +131,10 @@ export function registerDocumentTools(server, api) {
     {
       id: z.number().describe("Document ID to download. Get this from search_documents or get_document results."),
       original: z.boolean().optional().describe("Whether to download the original uploaded file (true) or the processed/archived version (false, default). Original files preserve exact formatting but may not include OCR improvements."),
+    },
+    {
+      title: "Download Document",
+      readOnlyHint: true,
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -6,7 +6,12 @@ export function registerTagTools(server, api) {
     "Retrieve all available tags for labeling and organizing documents. Returns tag names, colors, and matching rules for automatic assignment.",
     {
     // No parameters - returns all available tags
-  }, async (args, extra) => {
+  },
+  {
+    title: "List Tags",
+    readOnlyHint: true,
+  },
+  async (args, extra) => {
     if (!api) throw new Error("Please configure API connection first");
     return api.getTags();
   });
@@ -22,6 +27,10 @@ export function registerTagTools(server, api) {
         .optional().describe("Hex color code for visual identification (e.g., '#FF0000' for red, '#00FF00' for green). If not provided, Paperless assigns a random color."),
       match: z.string().optional().describe("Text pattern to automatically assign this tag to matching documents. Use keywords, phrases, or regular expressions depending on matching_algorithm."),
       matching_algorithm: z.number().int().min(0).max(4).optional().describe("How to match text patterns: 0=any word, 1=all words, 2=exact phrase, 3=regular expression, 4=fuzzy matching. Default is 0 (any word)."),
+    },
+    {
+      title: "Create Tag",
+      destructiveHint: true,
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
@@ -42,6 +51,10 @@ export function registerTagTools(server, api) {
       match: z.string().optional().describe("Text pattern for automatic tag assignment. Empty string removes auto-matching. Use keywords, phrases, or regex depending on matching_algorithm."),
       matching_algorithm: z.number().int().min(0).max(4).optional().describe("Algorithm for pattern matching: 0=any word, 1=all words, 2=exact phrase, 3=regular expression, 4=fuzzy matching."),
     },
+    {
+      title: "Update Tag",
+      destructiveHint: true,
+    },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       return api.updateTag(args.id, args);
@@ -53,6 +66,10 @@ export function registerTagTools(server, api) {
     "Permanently delete a tag from the system. This removes the tag from all documents that currently use it. Use with caution as this action cannot be undone.",
     {
       id: z.number().describe("ID of the tag to permanently delete. This will remove the tag from all documents that currently use it. Use list_tags to find tag IDs."),
+    },
+    {
+      title: "Delete Tag",
+      destructiveHint: true,
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
@@ -80,6 +97,10 @@ export function registerTagTools(server, api) {
         })
         .optional().describe("Permission settings when operation is 'set_permissions'. Defines who can view/use and modify these tags."),
       merge: z.boolean().optional().describe("Whether to merge with existing permissions (true) or replace them entirely (false). Default is false."),
+    },
+    {
+      title: "Bulk Edit Tags",
+      destructiveHint: true,
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`) to all 16 tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

- Added `readOnlyHint: true` to read-only tools (queries, fetches):
  - `get_document`, `search_documents`, `download_document`
  - `list_tags`, `list_correspondents`, `list_document_types`

- Added `destructiveHint: true` to tools that create/update/delete data:
  - `bulk_edit_documents`, `post_document`
  - `create_tag`, `update_tag`, `delete_tag`, `bulk_edit_tags`
  - `create_correspondent`, `bulk_edit_correspondents`
  - `create_document_type`, `bulk_edit_document_types`

- Added `title` annotations for human-readable display

## Why This Matters

- Annotations provide semantic metadata that helps LLMs understand tool behavior
- LLMs can make better decisions about when to use tools and in what order
- Enables safer tool execution by distinguishing read-only from destructive operations
- MCP clients like Claude Code can auto-approve read-only tools without user confirmation

## Testing

- [x] Server builds successfully (`npm run build`)
- [x] **Live verification:** Started server and confirmed `tools/list` returns annotations
- [x] All 16 tools have correct annotation values:
  - 6 read-only tools with `readOnlyHint: true`
  - 10 destructive tools with `destructiveHint: true`

## Verification Output

```
Total tools: 16

Tool Name                      Title                     ReadOnly   Destructive
---------------------------------------------------------------------------
bulk_edit_documents            Bulk Edit Documents       N/A        True      
post_document                  Post Document             N/A        True      
get_document                   Get Document              True       N/A       
search_documents               Search Documents          True       N/A       
download_document              Download Document         True       N/A       
list_tags                      List Tags                 True       N/A       
create_tag                     Create Tag                N/A        True      
update_tag                     Update Tag                N/A        True      
delete_tag                     Delete Tag                N/A        True      
bulk_edit_tags                 Bulk Edit Tags            N/A        True      
list_correspondents            List Correspondents       True       N/A       
create_correspondent           Create Correspondent      N/A        True      
bulk_edit_correspondents       Bulk Edit Correspondents  N/A        True      
list_document_types            List Document Types       True       N/A       
create_document_type           Create Document Type      N/A        True      
bulk_edit_document_types       Bulk Edit Document Types  N/A        True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)