### PR TITLE
feat: add custom fields support

### DIFF
--- a/src/api/PaperlessAPI.ts
+++ b/src/api/PaperlessAPI.ts
@@ -191,6 +191,31 @@ export class PaperlessAPI {
     });
   }
 
+  // Custom field operations
+  async getCustomFields() {
+    return this.request("/custom_fields/");
+  }
+
+  async createCustomField(data) {
+    return this.request("/custom_fields/", {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  }
+
+  async updateCustomField(id, data) {
+    return this.request(`/custom_fields/${id}/`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteCustomField(id) {
+    return this.request(`/custom_fields/${id}/`, {
+      method: "DELETE",
+    });
+  }
+
   // Bulk object operations
   async bulkEditObjects(objects, objectType, operation, parameters = {}) {
     return this.request("/bulk_edit_objects/", {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import express from "express";
 import { PaperlessAPI } from "./api/PaperlessAPI";
 import { registerCorrespondentTools } from "./tools/correspondents";
+import { registerCustomFieldTools } from "./tools/customFields";
 import { registerDocumentTools } from "./tools/documents";
 import { registerDocumentTypeTools } from "./tools/documentTypes";
 import { registerTagTools } from "./tools/tags";
@@ -56,6 +57,7 @@ async function main() {
   registerTagTools(server, api);
   registerCorrespondentTools(server, api);
   registerDocumentTypeTools(server, api);
+  registerCustomFieldTools(server, api);
 
   if (useHttp) {
     const app = express();

--- a/src/tools/customFields.ts
+++ b/src/tools/customFields.ts
@@ -1,0 +1,71 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
+import { z } from "zod";
+
+export function registerCustomFieldTools(server: McpServer, api) {
+  server.tool(
+    "list_custom_fields",
+    "Retrieve all available custom fields for storing additional document metadata. Returns field definitions including name, data type, and configuration options. Custom fields enable storing structured data like invoice numbers, amounts, dates, or links to external systems.",
+    {},
+    async (args, extra) => {
+      if (!api) throw new Error("Please configure API connection first");
+      return api.getCustomFields();
+    }
+  );
+
+  server.tool(
+    "create_custom_field",
+    "Create a new custom field for storing additional document metadata. Custom fields can store various data types including text, numbers, dates, booleans, URLs, monetary values, document links, and selection lists. Useful for integrating with external systems or tracking domain-specific information.",
+    {
+      name: z.string().describe("Unique name for the custom field (e.g., 'Invoice Number', 'Amount Due', 'External ID'). This name appears in the document detail view."),
+      data_type: z.enum([
+        "string",
+        "url",
+        "date",
+        "boolean",
+        "integer",
+        "float",
+        "monetary",
+        "documentlink",
+        "select"
+      ]).describe("Data type for the field: 'string' (text), 'url' (web link), 'date' (ISO date), 'boolean' (true/false), 'integer' (whole number), 'float' (decimal number), 'monetary' (currency value with 2 decimals), 'documentlink' (reference to another document), 'select' (dropdown with predefined options)."),
+      extra_data: z.object({
+        select_options: z.array(z.string()).optional().describe("Options for 'select' type fields. Each string becomes a dropdown option."),
+        default_currency: z.string().optional().describe("Default currency code for 'monetary' type fields (e.g., 'USD', 'EUR')."),
+      }).optional().describe("Additional configuration depending on data_type. Required for 'select' type (provide select_options). Optional for 'monetary' type (provide default_currency)."),
+    },
+    async (args, extra) => {
+      if (!api) throw new Error("Please configure API connection first");
+      return api.createCustomField(args);
+    }
+  );
+
+  server.tool(
+    "update_custom_field",
+    "Modify an existing custom field's name or configuration. Note: Changing data_type may cause data loss for existing values. Use with caution on fields that already have document values.",
+    {
+      id: z.number().describe("ID of the custom field to update. Use list_custom_fields to find existing field IDs."),
+      name: z.string().optional().describe("New name for the custom field. Leave empty to keep current name."),
+      extra_data: z.object({
+        select_options: z.array(z.string()).optional().describe("Updated options for 'select' type fields. This replaces all existing options."),
+        default_currency: z.string().optional().describe("Updated default currency for 'monetary' type fields."),
+      }).optional().describe("Updated configuration for the field. Only applicable fields will be modified."),
+    },
+    async (args, extra) => {
+      if (!api) throw new Error("Please configure API connection first");
+      const { id, ...data } = args;
+      return api.updateCustomField(id, data);
+    }
+  );
+
+  server.tool(
+    "delete_custom_field",
+    "Permanently delete a custom field from the system. This removes the field definition AND all values stored in this field across all documents. Use with extreme caution as this action cannot be undone.",
+    {
+      id: z.number().describe("ID of the custom field to permanently delete. WARNING: This will delete the field and ALL its values from every document. Use list_custom_fields to find field IDs."),
+    },
+    async (args, extra) => {
+      if (!api) throw new Error("Please configure API connection first");
+      return api.deleteCustomField(args.id);
+    }
+  );
+}


### PR DESCRIPTION
## Summary

Adds complete CRUD operations for Paperless-ngx custom fields, enabling storage of additional structured metadata on documents.

### New tools:
- `list_custom_fields` - Retrieve all custom field definitions
- `create_custom_field` - Create new fields with various data types
- `update_custom_field` - Modify field name or configuration  
- `delete_custom_field` - Remove field and all associated values

### Supported data types:
| Type | Description |
|------|-------------|
| `string` | Plain text |
| `url` | Web links |
| `date` | ISO date values |
| `boolean` | True/false |
| `integer` | Whole numbers |
| `float` | Decimal numbers |
| `monetary` | Currency values (with configurable default currency) |
| `documentlink` | References to other documents |
| `select` | Dropdown with predefined options |

### Use cases:
- Store invoice numbers, amounts, due dates
- Link documents to external system IDs
- Create custom categorization with select fields
- Track document relationships with documentlink type

## Changes
- `src/api/PaperlessAPI.ts`: Added CRUD methods for custom fields
- `src/tools/customFields.ts`: New file with 4 tools
- `src/index.ts`: Register custom field tools

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] list_custom_fields returns field definitions
- [ ] create_custom_field with string type
- [ ] create_custom_field with select type and options
- [ ] update_custom_field name change
- [ ] delete_custom_field removes field

---
🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom field management is now available with complete CRUD operations—users can list, create, update, and delete custom fields to customize their workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->