### PR TITLE
feat: add update and delete for correspondents and document types

### DIFF
--- a/src/api/PaperlessAPI.ts
+++ b/src/api/PaperlessAPI.ts
@@ -179,6 +179,19 @@ export class PaperlessAPI {
     });
   }
 
+  async updateCorrespondent(id, data) {
+    return this.request(`/correspondents/${id}/`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteCorrespondent(id) {
+    return this.request(`/correspondents/${id}/`, {
+      method: "DELETE",
+    });
+  }
+
   // Document type operations
   async getDocumentTypes() {
     return this.request("/document_types/");
@@ -188,6 +201,19 @@ export class PaperlessAPI {
     return this.request("/document_types/", {
       method: "POST",
       body: JSON.stringify(data),
+    });
+  }
+
+  async updateDocumentType(id, data) {
+    return this.request(`/document_types/${id}/`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteDocumentType(id) {
+    return this.request(`/document_types/${id}/`, {
+      method: "DELETE",
     });
   }
 

--- a/src/tools/correspondents.ts
+++ b/src/tools/correspondents.ts
@@ -27,6 +27,36 @@ export function registerCorrespondentTools(server: McpServer, api) {
   );
 
   server.tool(
+    "update_correspondent",
+    "Modify an existing correspondent's name or automatic matching rules. Useful for correcting names, improving automatic document assignment, or reorganizing correspondent categories.",
+    {
+      id: z.number().describe("ID of the correspondent to update. Use list_correspondents to find existing correspondent IDs."),
+      name: z.string().optional().describe("New name for the correspondent. Leave empty to keep current name."),
+      match: z.string().optional().describe("Text pattern for automatic assignment. Empty string removes auto-matching. Use names, email addresses, or keywords."),
+      matching_algorithm: z
+        .enum(["any", "all", "exact", "regular expression", "fuzzy"])
+        .optional().describe("Algorithm for pattern matching: 'any'=any word, 'all'=all words, 'exact'=exact phrase, 'regular expression'=regex, 'fuzzy'=approximate."),
+    },
+    async (args, extra) => {
+      if (!api) throw new Error("Please configure API connection first");
+      const { id, ...data } = args;
+      return api.updateCorrespondent(id, data);
+    }
+  );
+
+  server.tool(
+    "delete_correspondent",
+    "Permanently delete a correspondent from the system. Documents using this correspondent will have their correspondent field set to null. Use with caution as this action cannot be undone.",
+    {
+      id: z.number().describe("ID of the correspondent to permanently delete. Documents using this correspondent will lose their correspondent assignment. Use list_correspondents to find correspondent IDs."),
+    },
+    async (args, extra) => {
+      if (!api) throw new Error("Please configure API connection first");
+      return api.deleteCorrespondent(args.id);
+    }
+  );
+
+  server.tool(
     "bulk_edit_correspondents",
     "Perform bulk operations on multiple correspondents: set permissions to control who can assign them to documents, or permanently delete multiple correspondents. Use with caution as deletion affects all associated documents.",
     {

--- a/src/tools/documentTypes.ts
+++ b/src/tools/documentTypes.ts
@@ -28,6 +28,36 @@ export function registerDocumentTypeTools(server, api) {
   );
 
   server.tool(
+    "update_document_type",
+    "Modify an existing document type's name or automatic matching rules. Useful for improving document classification accuracy or reorganizing document categories.",
+    {
+      id: z.number().describe("ID of the document type to update. Use list_document_types to find existing document type IDs."),
+      name: z.string().optional().describe("New name for the document type. Leave empty to keep current name."),
+      match: z.string().optional().describe("Text pattern for automatic classification. Empty string removes auto-matching. Use keywords typical for this document type."),
+      matching_algorithm: z
+        .enum(["any", "all", "exact", "regular expression", "fuzzy"])
+        .optional().describe("Algorithm for pattern matching: 'any'=any word, 'all'=all words, 'exact'=exact phrase, 'regular expression'=regex, 'fuzzy'=approximate."),
+    },
+    async (args, extra) => {
+      if (!api) throw new Error("Please configure API connection first");
+      const { id, ...data } = args;
+      return api.updateDocumentType(id, data);
+    }
+  );
+
+  server.tool(
+    "delete_document_type",
+    "Permanently delete a document type from the system. Documents using this type will have their document_type field set to null. Use with caution as this action cannot be undone.",
+    {
+      id: z.number().describe("ID of the document type to permanently delete. Documents using this type will lose their classification. Use list_document_types to find document type IDs."),
+    },
+    async (args, extra) => {
+      if (!api) throw new Error("Please configure API connection first");
+      return api.deleteDocumentType(args.id);
+    }
+  );
+
+  server.tool(
     "bulk_edit_document_types",
     "Perform bulk operations on multiple document types: set permissions to control who can assign them to documents, or permanently delete multiple types. Use with caution as deletion affects all associated documents.",
     {


### PR DESCRIPTION
## Summary

Completes CRUD coverage for correspondents and document types by adding update and delete operations.

### New tools:

#### Correspondents:
- `update_correspondent` - Modify name or automatic matching rules
- `delete_correspondent` - Permanently remove correspondent from system

#### Document Types:
- `update_document_type` - Modify name or automatic matching rules  
- `delete_document_type` - Permanently remove document type from system

### Consistency with tags
This brings correspondents and document types to feature parity with tags, which already have `update_tag` and `delete_tag` tools.

## Changes
- `src/api/PaperlessAPI.ts`: Added update/delete methods for both resource types
- `src/tools/correspondents.ts`: Added 2 new tools
- `src/tools/documentTypes.ts`: Added 2 new tools

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] `update_correspondent` modifies correspondent name
- [ ] `delete_correspondent` removes correspondent
- [ ] `update_document_type` modifies type name
- [ ] `delete_document_type` removes document type

---
🤖 Generated with [Claude Code](https://claude.ai/code)