### PR TITLE
fix: return proper MCP ContentBlock format and fix matching_algorithm type

### DIFF
--- a/src/tools/correspondents.ts
+++ b/src/tools/correspondents.ts
@@ -7,7 +7,8 @@ export function registerCorrespondentTools(server: McpServer, api) {
     "Retrieve all available correspondents (people, companies, organizations that send/receive documents). Returns names and automatic matching patterns for document assignment.",
     { }, async (args, extra) => {
     if (!api) throw new Error("Please configure API connection first");
-    return api.getCorrespondents();
+    const result = await api.getCorrespondents();
+    return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
   });
 
   server.tool(

--- a/src/tools/correspondents.ts
+++ b/src/tools/correspondents.ts
@@ -22,7 +22,17 @@ export function registerCorrespondentTools(server: McpServer, api) {
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
-      return api.createCorrespondent(args);
+      const algorithmMap: Record<string, number> = {
+        any: 1, all: 2, exact: 3, "regular expression": 4, fuzzy: 5,
+      };
+      const payload = {
+        ...args,
+        ...(args.matching_algorithm !== undefined && {
+          matching_algorithm: algorithmMap[args.matching_algorithm],
+        }),
+      };
+      const result = await api.createCorrespondent(payload);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
     }
   );
 

--- a/src/tools/documentTypes.ts
+++ b/src/tools/documentTypes.ts
@@ -24,7 +24,17 @@ export function registerDocumentTypeTools(server, api) {
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
-      return api.createDocumentType(args);
+      const algorithmMap: Record<string, number> = {
+        any: 1, all: 2, exact: 3, "regular expression": 4, fuzzy: 5,
+      };
+      const payload = {
+        ...args,
+        ...(args.matching_algorithm !== undefined && {
+          matching_algorithm: algorithmMap[args.matching_algorithm],
+        }),
+      };
+      const result = await api.createDocumentType(payload);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
     }
   );
 

--- a/src/tools/documentTypes.ts
+++ b/src/tools/documentTypes.ts
@@ -8,7 +8,8 @@ export function registerDocumentTypeTools(server, api) {
     // No parameters - returns all available document types
   }, async (args, extra) => {
     if (!api) throw new Error("Please configure API connection first");
-    return api.getDocumentTypes();
+    const result = await api.getDocumentTypes();
+    return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
   });
 
   server.tool(

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -91,7 +91,9 @@ export function registerDocumentTools(server, api) {
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
-      return api.getDocument(args.id);
+      const result = await api.getDocument(args.id);
+      const { content: _ocr, ...meta } = result;
+      return { content: [{ type: "text" as const, text: JSON.stringify(meta, null, 2) }] };
     }
   );
 
@@ -105,7 +107,8 @@ export function registerDocumentTools(server, api) {
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
-      return api.searchDocuments(args.query, args.page, args.page_size);
+      const result = await api.searchDocuments(args.query, args.page, args.page_size);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
     }
   );
 

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -8,7 +8,8 @@ export function registerTagTools(server, api) {
     // No parameters - returns all available tags
   }, async (args, extra) => {
     if (!api) throw new Error("Please configure API connection first");
-    return api.getTags();
+    const result = await api.getTags();
+    return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
   });
 
   server.tool(


### PR DESCRIPTION
## Summary

- **ContentBlock format**: All tool handlers that returned raw API objects now return `{ content: [{ type: "text", text: JSON.stringify(result) }] }` as required by MCP SDK v1.11.x. Without this, tools either show "no output" (missing `content` key) or cause "Connection closed" (Paperless's `content` OCR field being mistaken for `ContentBlock[]`).
- **matching_algorithm type**: `create_correspondent` and `create_document_type` accepted string enums (`"any"`, `"all"`, `"exact"`, `"regular expression"`, `"fuzzy"`) via Zod but sent them as strings to the Paperless API, which expects integers. Added `algorithmMap` conversion in both handlers. `create_tag` was already using `z.number()` and unaffected.

## Affected tools

| Tool | Fix |
|------|-----|
| `list_correspondents` | ContentBlock wrap |
| `list_tags` | ContentBlock wrap |
| `list_document_types` | ContentBlock wrap |
| `search_documents` | ContentBlock wrap |
| `get_document` | ContentBlock wrap + strip OCR `content` field to prevent schema collision |
| `create_correspondent` | ContentBlock wrap + `matching_algorithm` string→integer conversion |
| `create_document_type` | ContentBlock wrap + `matching_algorithm` string→integer conversion |

## Root cause

MCP SDK 1.11.x validates tool responses against `CallToolResultSchema`, which requires `content: ContentBlock[]`. The Paperless document API returns a `content` field containing OCR text (a string), which the SDK misinterprets as a pre-formed response and fails validation — closing the connection. Tools returning objects without any `content` key silently produce "no output".

## Test plan

- [x] `list_correspondents` returns correspondent list
- [x] `list_tags` returns tag list  
- [x] `list_document_types` returns document type list
- [x] `search_documents` returns results
- [x] `create_correspondent` with `matching_algorithm: "any"` creates correspondent with integer value `1` in API
- [x] No connection close errors on any tool call

🤖 Generated with [Claude Code](https://claude.com/claude-code)