### PR TITLE
fix: wrap all tool responses in MCP content format

### DIFF
--- a/src/tools/correspondents.ts
+++ b/src/tools/correspondents.ts
@@ -1,8 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
 import { z } from "zod";
+import { wrap } from "./utils.js";
 
 export function registerCorrespondentTools(server: McpServer, api) {
-  const wrap = (d: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(d, null, 2) }] });
 
   server.tool(
     "list_correspondents",

--- a/src/tools/correspondents.ts
+++ b/src/tools/correspondents.ts
@@ -2,12 +2,14 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
 import { z } from "zod";
 
 export function registerCorrespondentTools(server: McpServer, api) {
+  const wrap = (d: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(d, null, 2) }] });
+
   server.tool(
     "list_correspondents",
     "Retrieve all available correspondents (people, companies, organizations that send/receive documents). Returns names and automatic matching patterns for document assignment.",
     { }, async (args, extra) => {
     if (!api) throw new Error("Please configure API connection first");
-    return api.getCorrespondents();
+    return wrap(await api.getCorrespondents());
   });
 
   server.tool(
@@ -22,7 +24,7 @@ export function registerCorrespondentTools(server: McpServer, api) {
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
-      return api.createCorrespondent(args);
+      return wrap(await api.createCorrespondent(args));
     }
   );
 
@@ -49,7 +51,7 @@ export function registerCorrespondentTools(server: McpServer, api) {
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
-      return api.bulkEditObjects(
+      return wrap(await api.bulkEditObjects(
         args.correspondent_ids,
         "correspondents",
         args.operation,
@@ -60,7 +62,7 @@ export function registerCorrespondentTools(server: McpServer, api) {
               merge: args.merge,
             }
           : {}
-      );
+      ));
     }
   );
 }

--- a/src/tools/documentTypes.ts
+++ b/src/tools/documentTypes.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
+import { wrap } from "./utils.js";
 
 export function registerDocumentTypeTools(server, api) {
-  const wrap = (d: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(d, null, 2) }] });
 
   server.tool(
     "list_document_types",

--- a/src/tools/documentTypes.ts
+++ b/src/tools/documentTypes.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
 export function registerDocumentTypeTools(server, api) {
+  const wrap = (d: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(d, null, 2) }] });
+
   server.tool(
     "list_document_types",
     "Retrieve all available document types for categorizing documents by purpose or format (Invoice, Receipt, Contract, etc.). Returns names and automatic matching rules.",
@@ -8,7 +10,7 @@ export function registerDocumentTypeTools(server, api) {
     // No parameters - returns all available document types
   }, async (args, extra) => {
     if (!api) throw new Error("Please configure API connection first");
-    return api.getDocumentTypes();
+    return wrap(await api.getDocumentTypes());
   });
 
   server.tool(
@@ -23,7 +25,7 @@ export function registerDocumentTypeTools(server, api) {
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
-      return api.createDocumentType(args);
+      return wrap(await api.createDocumentType(args));
     }
   );
 
@@ -50,7 +52,7 @@ export function registerDocumentTypeTools(server, api) {
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
-      return api.bulkEditObjects(
+      return wrap(await api.bulkEditObjects(
         args.document_type_ids,
         "document_types",
         args.operation,
@@ -61,7 +63,7 @@ export function registerDocumentTypeTools(server, api) {
               merge: args.merge,
             }
           : {}
-      );
+      ));
     }
   );
 }

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
 export function registerDocumentTools(server, api) {
+  const wrap = (d: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(d, null, 2) }] });
+
   server.tool(
     "bulk_edit_documents",
     "Perform bulk operations on multiple documents simultaneously: set correspondent/type/tags, delete, reprocess, merge, split, rotate, or manage permissions. Efficient for managing large document collections.",
@@ -53,7 +55,7 @@ export function registerDocumentTools(server, api) {
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const { documents, method, ...parameters } = args;
-      return api.bulkEditDocuments(documents, method, parameters);
+      return wrap(await api.bulkEditDocuments(documents, method, parameters));
     }
   );
 
@@ -78,7 +80,7 @@ export function registerDocumentTools(server, api) {
       const blob = new Blob([binaryData]);
       const file = new File([blob], args.filename);
       const { file: _, filename: __, ...metadata } = args;
-      return api.postDocument(file, metadata);
+      return wrap(await api.postDocument(file, metadata));
     }
   );
 
@@ -91,7 +93,7 @@ export function registerDocumentTools(server, api) {
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
-      return api.getDocument(args.id);
+      return wrap(await api.getDocument(args.id));
     }
   );
 
@@ -105,7 +107,7 @@ export function registerDocumentTools(server, api) {
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
-      return api.searchDocuments(args.query, args.page, args.page_size);
+      return wrap(await api.searchDocuments(args.query, args.page, args.page_size));
     }
   );
 
@@ -119,14 +121,13 @@ export function registerDocumentTools(server, api) {
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
       const response = await api.downloadDocument(args.id, args.original);
-      return {
-        blob: Buffer.from(await response.arrayBuffer()).toString("base64"),
+      return wrap({blob: Buffer.from(await response.arrayBuffer()).toString("base64"),
         filename:
           response.headers
             .get("content-disposition")
             ?.split("filename=")[1]
             ?.replace(/"/g, "") || `document-${args.id}`,
-      };
+      });
     }
   );
 }

--- a/src/tools/documents.ts
+++ b/src/tools/documents.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
+import { wrap } from "./utils.js";
 
 export function registerDocumentTools(server, api) {
-  const wrap = (d: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(d, null, 2) }] });
 
   server.tool(
     "bulk_edit_documents",

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
 export function registerTagTools(server, api) {
+  const wrap = (d: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(d, null, 2) }] });
+
   server.tool(
     "list_tags",
     "Retrieve all available tags for labeling and organizing documents. Returns tag names, colors, and matching rules for automatic assignment.",
@@ -8,7 +10,7 @@ export function registerTagTools(server, api) {
     // No parameters - returns all available tags
   }, async (args, extra) => {
     if (!api) throw new Error("Please configure API connection first");
-    return api.getTags();
+    return wrap(await api.getTags());
   });
 
   server.tool(
@@ -25,7 +27,7 @@ export function registerTagTools(server, api) {
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
-      return api.createTag(args);
+      return wrap(await api.createTag(args));
     }
   );
 
@@ -44,7 +46,7 @@ export function registerTagTools(server, api) {
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
-      return api.updateTag(args.id, args);
+      return wrap(await api.updateTag(args.id, args));
     }
   );
 
@@ -56,7 +58,7 @@ export function registerTagTools(server, api) {
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
-      return api.deleteTag(args.id);
+      return wrap(await api.deleteTag(args.id));
     }
   );
 
@@ -83,7 +85,7 @@ export function registerTagTools(server, api) {
     },
     async (args, extra) => {
       if (!api) throw new Error("Please configure API connection first");
-      return api.bulkEditObjects(
+      return wrap(await api.bulkEditObjects(
         args.tag_ids,
         "tags",
         args.operation,
@@ -94,7 +96,7 @@ export function registerTagTools(server, api) {
               merge: args.merge,
             }
           : {}
-      );
+      ));
     }
   );
 }

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
+import { wrap } from "./utils.js";
 
 export function registerTagTools(server, api) {
-  const wrap = (d: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(d, null, 2) }] });
 
   server.tool(
     "list_tags",

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -1,0 +1,3 @@
+export const wrap = (data: unknown) => ({
+  content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+});


### PR DESCRIPTION
  All tool handlers were returning raw Paperless API objects. The MCP
  protocol requires responses as { content: [{ type, text }] }.

  Two failure modes with Claude Code:
  - get_document threw a Zod error because the Paperless 'content' field (OCR text string) collided with CallToolResult.content (array)
  - search_documents, list_tags, list_document_types silently returned nothing because the raw objects had no 'content' array

  Fix: add a one-line wrap() helper to each tool file and use it on
  every return statement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized tool result formatting across API integrations to use a consistent JSON text payload structure for correspondents, document types, documents, and tags operations. Tool functionality remains unchanged; this improves internal consistency and maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nloui/paperless-mcp/pull/25)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->