### PR TITLE
fix: return MCP-compliant content[] from tool handlers (clients show "no output")

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,42 @@ async function main() {
   // Initialize API client and server once
   const api = new PaperlessAPI(baseUrl, token);
   const server = new McpServer({ name: "paperless-ngx", version: "1.0.0" });
+
+  // --- Compat-Shim (auer.uno): MCP-konformes Tool-Result erzwingen ---
+  // Die Tool-Handler geben rohe Paperless-API-Objekte zurueck (z.B. {count, results}).
+  // Der MCP-Standard / Claude-Code-Client erwartet { content: [{type:"text", text}] };
+  // fehlt content[], rendert der Client "no output" (=> Paperless wirkte komplett leer).
+  // Wir normalisieren daher zentral jeden registrierten Tool-Handler.
+  const _origTool = (server.tool as any).bind(server);
+  (server as any).tool = (...toolArgs: any[]) => {
+    const lastIdx = toolArgs.length - 1;
+    if (typeof toolArgs[lastIdx] === "function") {
+      const origHandler = toolArgs[lastIdx];
+      toolArgs[lastIdx] = async (...hArgs: any[]) => {
+        const result = await origHandler(...hArgs);
+        if (
+          result &&
+          typeof result === "object" &&
+          Array.isArray((result as any).content)
+        ) {
+          return result; // bereits MCP-konform
+        }
+        let text: string;
+        try {
+          text =
+            typeof result === "string"
+              ? result
+              : JSON.stringify(result, null, 2);
+        } catch {
+          text = String(result);
+        }
+        return { content: [{ type: "text", text }] };
+      };
+    }
+    return _origTool(...toolArgs);
+  };
+  // --- Ende Compat-Shim ---
+
   registerDocumentTools(server, api);
   registerTagTools(server, api);
   registerCorrespondentTools(server, api);


### PR DESCRIPTION
## Problem

When used with a strict MCP client (e.g. **Claude Code**), **every** tool (`search_documents`, `list_tags`, `list_correspondents`, `get_document`, …) returns **"completed with no output"** — even though the Paperless instance, token and routing are all fine and the same requests work via `curl`.

## Root cause

The tool handlers return the **raw Paperless REST object** directly, e.g. in `src/tools/tags.js`:

```js
server.tool("list_tags", "...", {}, async () => {
  if (!api) throw new Error("Please configure API connection first");
  return api.getTags();          // -> { count, next, previous, all, results }
});
```

But the MCP spec requires a `tools/call` result to be a `CallToolResult`, i.e. `{ content: [{ type: "text", text }] }`. A raw object has **no `content[]`**, so spec-compliant clients render nothing. Captured `tools/call` result for `list_tags`:

```json
{ "count": 14, "next": null, "previous": null, "all": [...], "results": [...] }   // no content[] -> "no output"
```

(Some lenient clients happen to display the raw object, which is why this can go unnoticed; Claude Code does not.)

## Fix

A single central shim in `src/index.ts` (right after `new McpServer(...)`) that wraps every registered tool handler and normalizes its return value into MCP `content[]`, while passing through results that are already MCP-compliant. One place, covers all current and future tools, no change to the individual tool files:

```ts
const _origTool = (server.tool as any).bind(server);
(server as any).tool = (...toolArgs: any[]) => {
  const lastIdx = toolArgs.length - 1;
  if (typeof toolArgs[lastIdx] === "function") {
    const origHandler = toolArgs[lastIdx];
    toolArgs[lastIdx] = async (...hArgs: any[]) => {
      const result = await origHandler(...hArgs);
      if (result && typeof result === "object" && Array.isArray((result as any).content)) {
        return result; // already MCP-compliant
      }
      const text = typeof result === "string" ? result : JSON.stringify(result, null, 2);
      return { content: [{ type: "text", text }] };
    };
  }
  return _origTool(...toolArgs);
};
```

## Testing

Built with `tsc` and exercised over a raw stdio handshake (`initialize` → `tools/call`):
- `list_tags` and `search_documents` now return `result.content[0].type === "text"` with the JSON payload.
- Verified against a live Paperless-ngx 2.20.x instance (690 documents); searches return the expected hits.

Source-only change (`build/` is gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for server tools so responses are consistently returned in the expected format.
  * Helped ensure tool results display correctly even when handlers return plain values instead of structured content.
  * Reduced the chance of malformed or missing output from tool actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->